### PR TITLE
change 2016SKUless to URLGetter

### DIFF
--- a/Office2016-IndividualApps/OfficeSuiteSKULessVersionProvider.py
+++ b/Office2016-IndividualApps/OfficeSuiteSKULessVersionProvider.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #
 # Copyright 2016 Allister Banks, lovingly based on work by Hannes Juutilainen
+
+# MODIFIED 20.03.09 RP --> removed urllib/urllib2 bits in favor of urlgetter from rtrouton's recipes
+
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,17 +18,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import urllib2
+from __future__ import absolute_import
+
 import xml.etree.ElementTree as ET
 
-from autopkglib import Processor, ProcessorError
-
+from autopkglib import Processor, ProcessorError, URLGetter
 
 __all__ = ["OfficeSuiteSKULessVersionProvider"]
 
-FEED_URL = "https://macadmins.software/versions.xml"
+FEED_URL = "https://macadmins.software/latest.xml"
 
-class OfficeSuiteSKULessVersionProvider(Processor):
+class OfficeSuiteSKULessVersionProvider(URLGetter):
     """Provides the version of the latest SKU-Less Office 2016 Suite release"""
     input_variables = {}
     output_variables = {
@@ -33,20 +37,20 @@ class OfficeSuiteSKULessVersionProvider(Processor):
         },
     }
     description = __doc__
-    
+
     def get_version(self, FEED_URL):
         """Parse the macadmins.software/versions.xml feed for the latest O365 version number"""
         try:
-            raw_xml = urllib2.urlopen(FEED_URL)
-            xml = raw_xml.read()
-        except BaseException as e:
+             xml = self.download(FEED_URL)
+        except Exception as e:
             raise ProcessorError("Can't download %s: %s" % (FEED_URL, e))
-        version = ''
+
         root = ET.fromstring(xml)
-        for vers in root.iter('latest'):
-            version = vers.find('o365').text
+        latest = root.find("latest")
+        for vers in root.iter("latest"):
+            version = vers.find("o365").text
         return version
-    
+
     def main(self):
         self.env["version"] = self.get_version(FEED_URL)
         self.output("Found Version Number %s" % self.env["version"])


### PR DESCRIPTION
This is basically copying/pasting from rtroutons recipes onto Office2016-IndividualApps/OfficeSuiteSKULessVersionProvider.py so it doesn't fail from using urllib2 anymore. I didn't look at or test the _other_ SKULessVersionProvider.py scripts (but I imagine those - if they use urllib2 - are failing as well). 

Cheers